### PR TITLE
Clarify external links, do general tidy-up

### DIFF
--- a/data/documentation.md
+++ b/data/documentation.md
@@ -19,7 +19,7 @@ This is what they look like:
 
 ###This is an H3 subheading
 
-Don't skip heading levels - ie straight to an H3. Don't insert an H1 anywhere.
+Don't skip heading levels - in other words, don't jump straight to an H3. Don't insert an H1 anywhere.
 
 ##Bold text
 
@@ -64,13 +64,13 @@ We only use numbered lists for describing steps as part of a process. Do this by
 
 `s3. Love numbers.`
 
-This looks like:
+This example follows the [style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#steps) and looks like:
 
 s1. Add numbers.
 s2. Check numbers.
 s3. Love numbers.
 
-Steps need an extra line break after the final step (ie 2 full blank lines). If you don't do this, other markdown directly after them won't work. If you have a subheading after numbered steps, add a line break after this.
+Steps need an extra line break after the final step (in other words, 2 full blank lines). If you don't do this, other markdown directly after them won't work. If you have a subheading after numbered steps, add a line break after this.
 
 ##Tables
 
@@ -105,13 +105,12 @@ This looks like:
 ###External links
 
 For external links, you need to include the full URL with http:// or www:
-Put the full stop within the square brackets if it's the end of a sentence.
 
-    [UK Parliament.](http://www.parliament.uk)
+    [UK Parliament](http://www.parliament.uk).
 
 This looks like:
 
-[UK Parliament.](http://www.parliament.uk)
+[UK Parliament](http://www.parliament.uk).
 
 ###Download links
 
@@ -173,11 +172,11 @@ $E
 
 ##Answer summaries
 
-Use these to sum up content in the 'quick answer' format in 1 or 2 sentences at the top of the page by adding '$!' to the start and end of the text. Don't use this anywhere else, or in any other formats.
+We no longer add this markdown to any new content. (You may still come across it in the 'quick answer' format.) 
 
   $! This is an answer summary. $!
-
-There's an example of what this looks like on the [Child Benefit rates](https://www.gov.uk/child-benefit-rates) quick answer.
+  
+If you see this markdown, you can delete it.
 
 ##Acronyms
 
@@ -185,13 +184,13 @@ List these in the following format at the end of the document and all occurrence
 
     *[FCO]: Foreign and Commonwealth Office
 
-This means the full text will appear when users hover of the acronym wherever it occurs on the page.
+This means the full text will appear when users hover over the acronym wherever it occurs on the page.
 
 ###Example of acronym use
 
 Example: PCSO and PCSOs are both in a piece of content.
 
-Always put the longer one first - otherwise PCSOs will pick up the singular only 'Police Community Support Officer'.
+Always put the longer one first in the list - otherwise PCSOs will pick up only the singular 'Police Community Support Officer'.
 
     *[PCSOs]: Police Community Support Officers  
     *[PCSO]: Police Community Support Officer


### PR DESCRIPTION
Change notes

https://trello.com/c/AxrachLa/433-review-and-update-the-govspeak-guide-in-github
(no Zendesk)

1. ###This is an H3 subheading

CHANGED

Don't skip heading levels - ie straight to an H3. Don't insert an H1 anywhere.

TO 

Don't skip heading levels - in other words, don't jump straight to an H3. Don't insert an H1 anywhere.

REASON: 'ie' is no longer house style.

2. Lists of steps

CHANGED

This looks like:

TO

This example follows the [style guide](https://www.gov.uk/guidance/style-guide/a-to-z-of-gov-uk-style#steps) and looks like:

REASON: content designers are sometimes confused about the house style for text in numbered steps, so this is just a reminder to follow the style in the example below.

3. ##External links

DELETED THIS SENTENCE

Put the full stop within the square brackets if it's the end of a sentence.

REASON: this is the only bit of guidance we need now.

4. CHANGED

[UK Parliament.](http://www.parliament.uk)

TO

[UK Parliament](http://www.parliament.uk).

REASON: the full stop needs to be a in a different place.

5. Answer summaries

CHANGED

Use these to sum up content in the 'quick answer' format in 1 or 2 sentences at the top of the page by adding '$!' to the start and end of the text. Don't use this anywhere else, or in any other formats.

TO

We no longer add this markdown to any new content. (You may still come across it in the 'quick answer' format.)

[Example]

If you see this markdown, you can delete it.

REASON: This markdown is no longer required (but we still need to mention it here as it can still be found in some old content.)  6. DELETED  There's an example of what this looks like on the Child Benefit rates quick answer.  REASON: We don’t need to show this example any more.

7. Acronyms

CHANGED

This means the full text will appear when users hover of the acronym wherever it occurs on the page.

TO 

This means the full text will appear when users hover over the acronym wherever it occurs on the page.

REASON: to correct a typo.

8. CHANGED

Always put the longer one first - otherwise PCSOs will pick up the singular only 'Police Community Support Officer'.

TO

Always put the longer one first in the list - otherwise PCSOs will pick up only the singular 'Police Community Support Officer'.

REASON: to make things clearer.